### PR TITLE
Only websockets require boto3, handle import separately

### DIFF
--- a/mangum/protocols/__init__.py
+++ b/mangum/protocols/__init__.py
@@ -1,2 +1,1 @@
-from .http import handle_http
-from .websockets import handle_ws
+


### PR DESCRIPTION
Raises an exception currently when importing the handlers. Probably a better way to do this, but this will fix the import error when websockets aren't being used.