### PR TITLE
Allow applications to handle exceptions, remove debug option, tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ pip3 install mangum
 
 The adapter class `Mangum` accepts the following optional arguments:
 
-- `debug` : bool (default=False)
-    
-    Enable a simple error response if an unhandled exception is raised in the adapter.
-
 - `enable_lifespan` : bool (default=True)
     
     Specify whether or not to enable lifespan support.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,10 +25,6 @@ pip3 install mangum
 
 The adapter class `Mangum` accepts the following optional arguments:
 
-- `debug` : bool (default=False)
-    
-    Enable a simple error response if an unhandled exception is raised in the adapter.
-
 - `enable_lifespan` : bool (default=True)
     
     Specify whether or not to enable lifespan support.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -190,3 +190,18 @@ def test_http_cycle_state(mock_http_event) -> None:
         "isBase64Encoded": False,
         "statusCode": 500,
     }
+
+    async def app(scope, receive, send):
+        assert scope["type"] == "http"
+        await send({"type": "http.response.start", "status": 200})
+        await send({"type": "http.response.start", "status": 200})
+
+    handler = Mangum(app, enable_lifespan=False)
+
+    response = handler(mock_http_event, {})
+    assert response == {
+        "body": "Internal Server Error",
+        "headers": {"content-type": "text/plain; charset=utf-8"},
+        "isBase64Encoded": False,
+        "statusCode": 500,
+    }


### PR DESCRIPTION
Refs https://github.com/erm/mangum/issues/60

* Wrapping the ASGI cycle run method to allow application frameworks (such as FastAPI and Starlette) to handle exception behaviour.
* Removing the `debug` statement (for now) - will probably re-introduce some generic form later. 