### PR TITLE
fixed type checking errors.

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -187,4 +187,3 @@ class Mangum:
             return make_response("OK", status_code=200)
 
         return make_response("Error", status_code=500)  # pragma: no cover
-

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -25,18 +25,12 @@ class Mangum:
     def __init__(
         self, app: ASGIApp, enable_lifespan: bool = True, log_level: str = "info"
     ) -> None:
-        # Incompatible types in assignment (expression has type
-        #                   "Callable[[Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]"
-        # variable has type "Callable[[Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]")
         self.app = app
         self.enable_lifespan = enable_lifespan
         self.log_level = log_level
         self.logger = get_logger(log_level=self.log_level)
         if self.enable_lifespan:
             loop = asyncio.get_event_loop()
-            # Argument 1 to "Lifespan" has incompatible type
-            #          "Callable[[                Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]"
-            # expected "Callable[[Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]"
             self.lifespan = Lifespan(self.app, self.logger)
             loop.create_task(self.lifespan.run())
             loop.run_until_complete(self.lifespan.wait_startup())
@@ -99,9 +93,6 @@ class Mangum:
         asgi_cycle.put_message(
             {"type": "http.request", "body": body, "more_body": False}
         )
-        # Argument 1 to "__call__" of "ASGIHTTPCycle" has incompatible type
-        #          "Callable[[                Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]"
-        # expected "Callable[[Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]
         response = asgi_cycle(self.app)
         return response
 
@@ -181,9 +172,6 @@ class Mangum:
             )
 
             try:
-                # Argument 1 to "__call__" of "ASGIWebSocketCycle" has incompatible type
-                #          "Callable[[                Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]"
-                # expected "Callable[[Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]], Awaitable[None]]"
                 asgi_cycle(self.app)
             except ASGIWebSocketCycleException:  # pragma: no cover
                 # TODO: Improve error handling

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -17,21 +17,18 @@ from mangum.exceptions import ASGIWebSocketCycleException
 from mangum.connections import ConnectionTable, __ERR__
 
 
+@dataclass
 class Mangum:
 
+    app: ASGIApp
     enable_lifespan: bool = True
     log_level: str = "info"
 
-    def __init__(
-        self, app: ASGIApp, enable_lifespan: bool = True, log_level: str = "info"
-    ) -> None:
-        self.app = app
-        self.enable_lifespan = enable_lifespan
-        self.log_level = log_level
+    def __post_init__(self,) -> None:
         self.logger = get_logger(log_level=self.log_level)
         if self.enable_lifespan:
             loop = asyncio.get_event_loop()
-            self.lifespan = Lifespan(self.app, self.logger)
+            self.lifespan = Lifespan(self.app, logger=self.logger)
             loop.create_task(self.lifespan.run())
             loop.run_until_complete(self.lifespan.wait_startup())
 

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -97,7 +97,7 @@ class Mangum:
         return response
 
     def handle_ws(self, event: dict, context: dict) -> dict:
-        if __ERR__:
+        if __ERR__:  # pragma: no cover
             raise ImportError(__ERR__)
 
         request_context = event["requestContext"]

--- a/mangum/connections.py
+++ b/mangum/connections.py
@@ -7,7 +7,7 @@ try:
     from boto3.dynamodb.conditions import Attr
 
     __ERR__ = ""
-except ImportError:
+except ImportError:  # pragma: no cover
     __ERR__ = "boto3 must be installed for WebSocket support."
 
 from mangum.exceptions import ConnectionTableException

--- a/mangum/connections.py
+++ b/mangum/connections.py
@@ -9,7 +9,6 @@ try:
     __ERR__ = ""
 except ImportError:
     __ERR__ = "boto3 must be installed for WebSocket support."
-    pass
 
 from mangum.exceptions import ConnectionTableException
 

--- a/mangum/connections.py
+++ b/mangum/connections.py
@@ -1,9 +1,15 @@
 import typing
 import os
 
-import boto3
-import botocore
-from boto3.dynamodb.conditions import Attr
+try:
+    import boto3
+    import botocore
+    from boto3.dynamodb.conditions import Attr
+
+    __ERR__ = ""
+except ImportError:
+    __ERR__ = "boto3 must be installed for WebSocket support."
+    pass
 
 from mangum.exceptions import ConnectionTableException
 

--- a/mangum/lifespan.py
+++ b/mangum/lifespan.py
@@ -24,7 +24,7 @@ class Lifespan:
     async def run(self) -> None:
         receive, send = (self.receiver(), self.sender())
         try:
-            await self.app({"type": "lifespan"}, receive, send)  #!
+            await self.app({"type": "lifespan"}, receive, send)
         except BaseException as exc:  # pragma: no cover
             self.logger.error(f"Exception in 'lifespan' protocol: {exc}")
         finally:

--- a/mangum/lifespan.py
+++ b/mangum/lifespan.py
@@ -6,20 +6,13 @@ from dataclasses import dataclass
 from mangum.types import ASGIApp, Message, Send, Receive
 
 
+@dataclass
 class Lifespan:
-    def __init__(
-        self,
-        app: ASGIApp,
-        logger: logging.Logger,
-        startup_event: asyncio.Event = asyncio.Event(),
-        shutdown_event: asyncio.Event = asyncio.Event(),
-        app_queue: asyncio.Queue = asyncio.Queue(),
-    ):
-        self.app = app
-        self.logger = logger
-        self.startup_event = startup_event
-        self.shutdown_event = shutdown_event
-        self.app_queue = app_queue
+    app: ASGIApp
+    logger: logging.Logger
+    startup_event: asyncio.Event = asyncio.Event()
+    shutdown_event: asyncio.Event = asyncio.Event()
+    app_queue: asyncio.Queue = asyncio.Queue()
 
     async def run(self) -> None:
         receive, send = (self.receiver(), self.sender())

--- a/mangum/lifespan.py
+++ b/mangum/lifespan.py
@@ -63,4 +63,3 @@ class Lifespan:
         self.logger.info("Waiting for application shutdown.")
         await self.app_queue.put({"type": "lifespan.shutdown"})
         await self.shutdown_event.wait()
-

--- a/mangum/lifespan.py
+++ b/mangum/lifespan.py
@@ -3,40 +3,56 @@ import logging
 import asyncio
 from dataclasses import dataclass
 
-from mangum.types import ASGIApp, Message
+from mangum.types import ASGIApp, Message, Send, Receive
 
 
-@dataclass
 class Lifespan:
-
-    app: ASGIApp
-    logger: logging.Logger
-    startup_event: asyncio.Event = asyncio.Event()
-    shutdown_event: asyncio.Event = asyncio.Event()
-    app_queue: asyncio.Queue = asyncio.Queue()
+    def __init__(
+        self,
+        app: ASGIApp,
+        logger: logging.Logger,
+        startup_event: asyncio.Event = asyncio.Event(),
+        shutdown_event: asyncio.Event = asyncio.Event(),
+        app_queue: asyncio.Queue = asyncio.Queue(),
+    ):
+        self.app = app
+        self.logger = logger
+        self.startup_event = startup_event
+        self.shutdown_event = shutdown_event
+        self.app_queue = app_queue
 
     async def run(self) -> None:
+        receive, send = (self.receiver(), self.sender())
         try:
-            await self.app({"type": "lifespan"}, self.receive, self.send)
+            await self.app({"type": "lifespan"}, receive, send)  #!
         except BaseException as exc:  # pragma: no cover
             self.logger.error(f"Exception in 'lifespan' protocol: {exc}")
         finally:
             self.startup_event.set()
             self.shutdown_event.set()
 
-    async def send(self, message: Message) -> None:
-        if message["type"] == "lifespan.startup.complete":
-            self.startup_event.set()
-        elif message["type"] == "lifespan.shutdown.complete":
-            self.shutdown_event.set()
-        else:  # pragma: no cover
-            raise RuntimeError(
-                f"Expected lifespan message type, received: {message['type']}"
-            )
+    def sender(self) -> Send:
+        # startup_event, shutdown_event = self.startup_event, self.shutdown_event
 
-    async def receive(self) -> Message:
-        message = await self.app_queue.get()
-        return message
+        async def send(message: Message) -> None:
+            message_type = message["type"]
+            if message_type == "lifespan.startup.complete":
+                self.startup_event.set()
+            elif message_type == "lifespan.shutdown.complete":
+                self.shutdown_event.set()
+            else:  # pragma: no cover
+                raise RuntimeError(
+                    f"Expected lifespan message type, received: {message_type}"
+                )
+            return None
+
+        return send
+
+    def receiver(self) -> Receive:
+        async def receive() -> Message:
+            return await self.app_queue.get()
+
+        return receive
 
     async def wait_startup(self) -> None:
         self.logger.info("Waiting for application startup.")
@@ -47,3 +63,4 @@ class Lifespan:
         self.logger.info("Waiting for application shutdown.")
         await self.app_queue.put({"type": "lifespan.shutdown"})
         await self.shutdown_event.wait()
+

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -37,7 +37,7 @@ class ASGIHTTPCycle:
         self.loop.run_until_complete(asgi_task)
         return self.response
 
-    async def run(self, app: ASGIApp) -> response:
+    async def run(self, app: ASGIApp) -> None:
         try:
             await app(self.scope, self.receive, self.send)
         except BaseException as exc:

--- a/mangum/protocols/websockets.py
+++ b/mangum/protocols/websockets.py
@@ -49,7 +49,7 @@ class ASGIWebSocketCycle:
                     f"Expected 'websocket.accept' or 'websocket.close', received: {message['type']}"
                 )
         else:
-            data = message.get("text", "")  # !
+            data = message.get("text", "")
             if message["type"] == "websocket.send":
                 group = message.get("group", None)
                 self.send_data(data=data, group=group)

--- a/mangum/protocols/websockets.py
+++ b/mangum/protocols/websockets.py
@@ -1,4 +1,5 @@
 import typing
+from typing import Optional
 import json
 import enum
 import asyncio
@@ -19,11 +20,11 @@ class ASGIState(enum.Enum):
 class ASGIWebSocketCycle:
 
     scope: Scope
+    endpoint_url: str
+    connection_id: str
+    connection_table: ConnectionTable
     state: ASGIState = ASGIState.REQUEST
     response: dict = field(default_factory=dict)
-    endpoint_url: str = None
-    connection_id: str = None
-    connection_table: ConnectionTable = None
 
     def __post_init__(self) -> None:
         self.loop = asyncio.get_event_loop()
@@ -48,7 +49,7 @@ class ASGIWebSocketCycle:
                     f"Expected 'websocket.accept' or 'websocket.close', received: {message['type']}"
                 )
         else:
-            data = message.get("text")
+            data = message.get("text", "")  # !
             if message["type"] == "websocket.send":
                 group = message.get("group", None)
                 self.send_data(data=data, group=group)

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -1,9 +1,9 @@
 import typing
 
-try:  # python 3.8+
-    from typing import Protocol
-except ImportError:  # python 2.7, 3.4-3.7
-    from typing_extensions import Protocol as _Protocol
+try:
+    from typing import Protocol  # python 3.8+
+except ImportError:
+    from typing_extensions import Protocol as _Protocol  # python 2.7, 3.4-3.7
 
     Protocol = typing.cast(typing._SpecialForm, _Protocol)
     # Otherwise, Protocol has incompatible type "typing_extensions._SpecialForm"
@@ -17,4 +17,4 @@ Send = typing.Callable[[Message], typing.Awaitable[None]]
 
 class ASGIApp(Protocol):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        ...
+        ...  # pragma: no cover

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -1,9 +1,20 @@
 import typing
 
+try:  # python 3.8+
+    from typing import Protocol
+except ImportError:  # python 2.7, 3.4-3.7
+    from typing_extensions import Protocol as _Protocol
+
+    Protocol = typing.cast(typing._SpecialForm, _Protocol)
+    # Otherwise, Protocol has incompatible type "typing_extensions._SpecialForm"
+
 Message = typing.Dict[str, typing.Any]
 
 Scope = typing.Dict[str, typing.Any]
 Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
 
-ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]
+
+class ASGIApp(Protocol):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        ...

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -1,7 +1,9 @@
 import typing
 
-Scope = typing.Dict[str, typing.Any]
 Message = typing.Dict[str, typing.Any]
+
+Scope = typing.Dict[str, typing.Any]
 Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
+
 ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]

--- a/scripts/test
+++ b/scripts/test
@@ -3,8 +3,10 @@
 export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
+    export PATH="venv/bin:$PATH"
 fi
 
-set -x
-
-PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=mangum --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
+set -x # print executed commands to the terminal
+mypy ./mangum
+PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=mangum --cov=tests --cov-fail-under=100 --cov-report=term-missing "${@}"
+black --check ./

--- a/scripts/test
+++ b/scripts/test
@@ -7,6 +7,7 @@ if [ -d 'venv' ] ; then
 fi
 
 set -x # print executed commands to the terminal
+
 mypy ./mangum
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=mangum --cov=tests --cov-fail-under=100 --cov-report=term-missing "${@}"
 black --check ./

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,11 @@
 
 max-line-length = 88
 ignore = E203, W503, F401
+
+[mypy]
+disallow_untyped_defs = True
+# disallow_any_decorated = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+ignore_missing_imports = True


### PR DESCRIPTION
Resolves #67.

I had to swap `@dataclass`es for `__init__(self, *args)` syntax to placate mypy.  It isn't ideal, but it was less dumb than other possible workarounds, such as having self.app be a tuple of (app: ASGIApp,).

<details><summary>demonstration of the trouble with <code>@dataclass</code></summary>

```python
from dataclasses import dataclass
from typing import Callable, Dict

Foo = Callable[[Dict[str, str]], int]


def foo(d: Dict[str, str]) -> int:
    return len(list(d.keys()))


@dataclass
class Bar:
    foo: Foo  # mypy thinks the first argument is `self`!

    def run(self, d: Dict[str, str]) -> None:
        print(self.foo(d))
        # Invalid self argument "Bar" to attribute function "foo" with type "Callable[[Dict[str, str]], int]"mypy(error)
        # Too many argumentsmypy(error)


bar = Bar(foo)
bar.run({"a": "1"})  # works, but doesn't pass the type checker


class Baz(object):
    def __init__(self, foo: Foo):
        self.foo = foo  # explicit enough that mypy doesn't think `self.foo` is passed `self`

    def run(self, d: Dict[str, str]) -> None:
        print(self.foo(d))

baz = Baz(foo)
bar.run({"a": "1"})  # works **and** passes type checking

```

</details>