### PR TITLE
Test Py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: pip
 
 python:
   - "3.7"
+  - "3.8"
 
 before_install:
   - export BOTO_CONFIG=/dev/null

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -25,7 +25,7 @@ class ASGIHTTPCycle:
 
     def __post_init__(self) -> None:
         self.loop = asyncio.get_event_loop()
-        self.app_queue: asyncio.Queue = asyncio.Queue(loop=self.loop)
+        self.app_queue: asyncio.Queue = asyncio.Queue()
         self.response["isBase64Encoded"] = self.is_binary
 
     def __call__(self, app: ASGIApp) -> dict:

--- a/mangum/protocols/websockets.py
+++ b/mangum/protocols/websockets.py
@@ -24,7 +24,7 @@ class ASGIWebSocketCycle:
 
     def __post_init__(self) -> None:
         self.loop = asyncio.get_event_loop()
-        self.app_queue: asyncio.Queue = asyncio.Queue(loop=self.loop)
+        self.app_queue: asyncio.Queue = asyncio.Queue()
 
     def __call__(self, app: ASGIApp) -> dict:
         asgi_instance = app(self.scope, self.receive, self.send)

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -2,7 +2,7 @@ import typing
 
 try:
     from typing import Protocol  # python 3.8+
-except ImportError:
+except ImportError:  # pragma: no cover
     from typing_extensions import Protocol as _Protocol  # python 3.7
 
     Protocol = typing.cast(typing._SpecialForm, _Protocol)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ codecov
 pytest-cov
 black
 starlette
-quart
+quart; python_version == '3.7'
 boto3
 botocore
 moto

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,4 +1,5 @@
 import base64
+
 import pytest
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,8 +1,19 @@
+import sys
+
 import pytest
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
-from quart import Quart
+
+
 from mangum import Mangum
+
+# One (or more) of Quart's dependencies does not support Python 3.8, ignore this case.
+IS_PY38 = sys.version_info[:2] == (3, 8)
+
+if not IS_PY38:
+    from quart import Quart
+else:
+    Quart = None
 
 
 @pytest.mark.parametrize("mock_http_event", [["GET", None]], indirect=True)
@@ -50,6 +61,9 @@ def test_starlette_response(mock_http_event) -> None:
     assert shutdown_complete
 
 
+@pytest.mark.skipif(
+    IS_PY38, reason="One (or more) of Quart's dependencies does not support Python 3.8."
+)
 @pytest.mark.parametrize("mock_http_event", [["GET", None]], indirect=True)
 def test_quart_app(mock_http_event) -> None:
     startup_complete = False

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,9 +1,11 @@
 import mock
+
 import pytest
-from mangum import Mangum
-from mangum.connections import ConnectionTable
 from starlette.applications import Starlette
 from starlette.websockets import WebSocket
+
+from mangum import Mangum
+from mangum.connections import ConnectionTable
 
 
 def test_websocket_events(


### PR DESCRIPTION
Refs https://github.com/erm/mangum/issues/71

Ignores Quart specific test when running Python 3.8, resolves deprecation warnings for passing event loop to queues, minor import formatting fixes.