### PR TITLE
add unitest for query_string

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import boto3
 def mock_http_event(request):
     method = request.param[0]
     body = request.param[1]
+    multi_value_query_parameters = request.param[2]
     event = {
         "path": "/test/hello",
         "body": body,
@@ -52,8 +53,12 @@ def mock_http_event(request):
         },
         "resource": "/{proxy+}",
         "httpMethod": method,
-        "queryStringParameters": {"name": "me"},
-        "multiValueQueryStringParameters": {"name": ["me", "you"]},
+        "queryStringParameters": {
+            k: v[0] for k, v in multi_value_query_parameters.items()
+        }
+        if multi_value_query_parameters
+        else None,
+        "multiValueQueryStringParameters": multi_value_query_parameters or None,
         "stageVariables": {"stageVarName": "stageVarValue"},
     }
     return event

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -6,7 +6,138 @@ from starlette.responses import PlainTextResponse
 from mangum import Mangum
 
 
-@pytest.mark.parametrize("mock_http_event", [["GET", None]], indirect=True)
+@pytest.mark.parametrize(
+    "mock_http_event,query_string",
+    [
+        (["GET", None, None], b""),
+        (["GET", None, {"name": ["me"]}], b"name=me"),
+        (["GET", None, {"name": ["me", "you"]}], b"name=me&name=you"),
+        (
+            ["GET", None, {"name": ["me", "you"], "pet": ["dog"]}],
+            b"name=me&name=you&pet=dog",
+        ),
+    ],
+    indirect=["mock_http_event"],
+)
+def test_http_request(mock_http_event, query_string) -> None:
+    async def app(scope, receive, send):
+        assert scope == {
+            "asgi": {"version": "3.0"},
+            "aws": {
+                "context": {},
+                "event": {
+                    "body": None,
+                    "headers": {
+                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                        "Accept-Encoding": "gzip, deflate, lzma, sdch, " "br",
+                        "Accept-Language": "en-US,en;q=0.8",
+                        "CloudFront-Forwarded-Proto": "https",
+                        "CloudFront-Is-Desktop-Viewer": "true",
+                        "CloudFront-Is-Mobile-Viewer": "false",
+                        "CloudFront-Is-SmartTV-Viewer": "false",
+                        "CloudFront-Is-Tablet-Viewer": "false",
+                        "CloudFront-Viewer-Country": "US",
+                        "Host": "test.execute-api.us-west-2.amazonaws.com",
+                        "Upgrade-Insecure-Requests": "1",
+                        "X-Forwarded-For": "192.168.100.1, 192.168.1.1",
+                        "X-Forwarded-Port": "443",
+                        "X-Forwarded-Proto": "https",
+                    },
+                    "httpMethod": "GET",
+                    "path": "/test/hello",
+                    "pathParameters": {"proxy": "hello"},
+                    "queryStringParameters": mock_http_event["queryStringParameters"],
+                    "multiValueQueryStringParameters": mock_http_event[
+                        "multiValueQueryStringParameters"
+                    ],
+                    "requestContext": {
+                        "accountId": "123456789012",
+                        "apiId": "123",
+                        "httpMethod": "GET",
+                        "identity": {
+                            "accountId": "",
+                            "apiKey": "",
+                            "caller": "",
+                            "cognitoAuthenticationProvider": "",
+                            "cognitoAuthenticationType": "",
+                            "cognitoIdentityId": "",
+                            "cognitoIdentityPoolId": "",
+                            "sourceIp": "192.168.100.1",
+                            "user": "",
+                            "userAgent": "Mozilla/5.0 "
+                            "(Macintosh; "
+                            "Intel Mac OS "
+                            "X 10_11_6) "
+                            "AppleWebKit/537.36 "
+                            "(KHTML, like "
+                            "Gecko) "
+                            "Chrome/52.0.2743.82 "
+                            "Safari/537.36 "
+                            "OPR/39.0.2256.48",
+                            "userArn": "",
+                        },
+                        "requestId": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
+                        "resourceId": "us4z18",
+                        "resourcePath": "/{proxy+}",
+                        "stage": "Prod",
+                    },
+                    "resource": "/{proxy+}",
+                    "stageVariables": {"stageVarName": "stageVarValue"},
+                },
+            },
+            "client": ("192.168.100.1", 0),
+            "headers": [
+                [
+                    b"accept",
+                    b"text/html,application/xhtml+xml,application/xml;q=0.9,image/"
+                    b"webp,*/*;q=0.8",
+                ],
+                [b"accept-encoding", b"gzip, deflate, lzma, sdch, br"],
+                [b"accept-language", b"en-US,en;q=0.8"],
+                [b"cloudfront-forwarded-proto", b"https"],
+                [b"cloudfront-is-desktop-viewer", b"true"],
+                [b"cloudfront-is-mobile-viewer", b"false"],
+                [b"cloudfront-is-smarttv-viewer", b"false"],
+                [b"cloudfront-is-tablet-viewer", b"false"],
+                [b"cloudfront-viewer-country", b"US"],
+                [b"host", b"test.execute-api.us-west-2.amazonaws.com"],
+                [b"upgrade-insecure-requests", b"1"],
+                [b"x-forwarded-for", b"192.168.100.1, 192.168.1.1"],
+                [b"x-forwarded-port", b"443"],
+                [b"x-forwarded-proto", b"https"],
+            ],
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/test/hello",
+            "query_string": query_string,
+            "raw_path": None,
+            "root_path": "",
+            "scheme": "https",
+            "server": ("test.execute-api.us-west-2.amazonaws.com", 80),
+            "type": "http",
+        }
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain; charset=utf-8"]],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+    handler = Mangum(app, enable_lifespan=False)
+    response = handler(mock_http_event, {})
+    assert response == {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "headers": {"content-type": "text/plain; charset=utf-8"},
+        "body": "Hello, world!",
+    }
+
+
+@pytest.mark.parametrize(
+    "mock_http_event", [["GET", None, {"name": ["me", "you"]}]], indirect=True
+)
 def test_http_response(mock_http_event) -> None:
     async def app(scope, receive, send):
         assert scope == {
@@ -121,7 +252,7 @@ def test_http_response(mock_http_event) -> None:
     }
 
 
-@pytest.mark.parametrize("mock_http_event", [["GET", "123"]], indirect=True)
+@pytest.mark.parametrize("mock_http_event", [["GET", "123", None]], indirect=True)
 def test_http_response_with_body(mock_http_event) -> None:
     async def app(scope, receive, send):
         assert scope["type"] == "http"
@@ -157,7 +288,7 @@ def test_http_response_with_body(mock_http_event) -> None:
 
 
 @pytest.mark.parametrize(
-    "mock_http_event", [["GET", base64.b64encode(b"123")]], indirect=True
+    "mock_http_event", [["GET", base64.b64encode(b"123"), None]], indirect=True
 )
 def test_http_binary_response_with_body(mock_http_event) -> None:
     async def app(scope, receive, send):
@@ -193,7 +324,7 @@ def test_http_binary_response_with_body(mock_http_event) -> None:
     }
 
 
-@pytest.mark.parametrize("mock_http_event", [["GET", None]], indirect=True)
+@pytest.mark.parametrize("mock_http_event", [["GET", None, None]], indirect=True)
 def test_http_exception(mock_http_event) -> None:
     async def app(scope, receive, send):
         await send({"type": "http.response.start", "status": 200})
@@ -211,7 +342,7 @@ def test_http_exception(mock_http_event) -> None:
     }
 
 
-@pytest.mark.parametrize("mock_http_event", [["GET", None]], indirect=True)
+@pytest.mark.parametrize("mock_http_event", [["GET", None, None]], indirect=True)
 def test_http_exception_handler(mock_http_event) -> None:
     path = mock_http_event["path"]
     app = Starlette()
@@ -236,7 +367,7 @@ def test_http_exception_handler(mock_http_event) -> None:
     }
 
 
-@pytest.mark.parametrize("mock_http_event", [["GET", ""]], indirect=True)
+@pytest.mark.parametrize("mock_http_event", [["GET", "", None]], indirect=True)
 def test_http_cycle_state(mock_http_event) -> None:
     async def app(scope, receive, send):
         assert scope["type"] == "http"

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -17,7 +17,7 @@ else:
     Quart = None
 
 
-@pytest.mark.parametrize("mock_http_event", [["GET", None]], indirect=True)
+@pytest.mark.parametrize("mock_http_event", [["GET", None, None]], indirect=True)
 def test_starlette_response(mock_http_event) -> None:
     startup_complete = False
     shutdown_complete = False
@@ -66,7 +66,7 @@ def test_starlette_response(mock_http_event) -> None:
     IS_PY38, reason="One (or more) of Quart's dependencies does not support Python 3.8."
 )
 @pytest.mark.skipif(IS_PY36, reason="Quart does not support Python 3.6.")
-@pytest.mark.parametrize("mock_http_event", [["GET", None]], indirect=True)
+@pytest.mark.parametrize("mock_http_event", [["GET", None, None]], indirect=True)
 def test_quart_app(mock_http_event) -> None:
     startup_complete = False
     shutdown_complete = False


### PR DESCRIPTION
This PR adds unittest for `query_string`

@erm 
I add a test for request and change `mock_http_event` to support query parameters.
If you don't prefer the change then, please tell me it. 

## Related Issues
https://github.com/erm/mangum/issues/80 