### PR TITLE
make 'headers' key in event optional

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -21,7 +21,7 @@ def get_server_and_client(event: dict) -> typing.Tuple:  # pragma: no cover
     client_addr = event["requestContext"].get("identity", {}).get("sourceIp", None)
     client = (client_addr, 0)
 
-    server_addr = event["headers"].get("Host", None)
+    server_addr = event.get("headers", {}).get("Host", None)
 
     if server_addr is not None:
         if ":" not in server_addr:


### PR DESCRIPTION
as in some case (especially right after a new release ?) api gateway does not seem to send the header key in the event