### PR TITLE
Support testing with no headers

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -21,7 +21,8 @@ def get_server_and_client(event: dict) -> typing.Tuple:  # pragma: no cover
     client_addr = event["requestContext"].get("identity", {}).get("sourceIp", None)
     client = (client_addr, 0)
 
-    server_addr = event.get("headers", {}).get("Host", None)
+    headers = event.get("headers") or {}
+    server_addr = headers.get("Host", None)
 
     if server_addr is not None:
         if ":" not in server_addr:


### PR DESCRIPTION
This fixes a bug that prevents testing via API Gateway console.

**Steps to reproduce:**

1. Deploy ASGI app on AWS Lambda using mangum handler, configured to run behind API Gateway with `{proxy+}` path and `ANY` method.
3. In the API Gateway console, go to the method and select "TEST".
4. Set the method to `GET` and path to any valid path to GET from your app, but leave the Headers textarea empty.

**Problem**

Mangum throws the following exception:

```
  File "/var/task/mangum/adapter.py", line 60, in __call__
    raise exc
  File "/var/task/mangum/adapter.py", line 58, in __call__
    response = self.handler(event, context)
  File "/var/task/mangum/adapter.py", line 72, in handler
    response = self.handle_http(event, context)
  File "/var/task/mangum/adapter.py", line 84, in handle_http
    server, client = get_server_and_client(event)
  File "/var/task/mangum/adapter.py", line 24, in get_server_and_client
    server_addr = event.get("headers", {}).get("Host", None)
```

In this case, `event["headers"] is None`. This small change supports this scenario.