### PR TITLE
fix types between mangum and fastapi

### DIFF
--- a/mangum/types.py
+++ b/mangum/types.py
@@ -1,8 +1,8 @@
 import typing
 from typing_extensions import Protocol
 
-Message = typing.Dict[str, typing.Any]
-Scope = typing.Dict[str, typing.Any]
+Message = typing.MutableMapping[str, typing.Any]
+Scope = typing.MutableMapping[str, typing.Any]
 Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
 


### PR DESCRIPTION
mangum was checking for more concrete types than fastapi, causing errors when one was running mypy

it should fixes https://github.com/erm/mangum-examples/issues/2