### PR TITLE
adding support for api gateway's new http apis

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -16,15 +16,21 @@ from mangum.connections import ConnectionTable, __ERR__
 TEXT_MIME_TYPES = ("text/.*", r".*\bjson", r".*\bxml")
 
 
-def get_server_and_client(event: dict) -> typing.Tuple:  # pragma: no cover
+def get_server_and_client(event: dict,
+                          is_http_api: bool = False) -> typing.Tuple:  # pragma: no cover
     """
     Parse the server and client for the scope definition, if possible.
     """
-    client_addr = event["requestContext"].get("identity", {}).get("sourceIp", None)
+
+    if is_http_api:
+        client_addr = event["requestContext"]['http']['sourceIp']
+    else:
+        client_addr = event["requestContext"].get("identity", {}).get("sourceIp", None)
+
     client = (client_addr, 0)
 
     headers = event.get("headers") or {}
-    server_addr = headers.get("Host", None)
+    server_addr = headers.get("host") if is_http_api else headers.get("Host")
 
     if server_addr is not None:
         if ":" not in server_addr:
@@ -72,7 +78,8 @@ class Mangum:
         return urllib.parse.unquote(path or "/")
 
     def handler(self, event: dict, context: dict) -> dict:
-        if "httpMethod" in event:
+
+        if not 'eventType' in event['requestContext']:
             response = self.handle_http(event, context)
         else:
 
@@ -85,36 +92,45 @@ class Mangum:
         return response
 
     def handle_http(self, event: dict, context: dict) -> dict:
-        server, client = get_server_and_client(event)
+        is_http_api = 'multiValueQueryStringParameters' not in event
+        server, client = get_server_and_client(event, is_http_api)
         headers = event.get("headers") or {}
         headers_key_value_pairs = [
             [k.lower().encode(), v.encode()] for k, v in headers.items()
         ]
-        multi_value_query_string_params = event["multiValueQueryStringParameters"]
-        query_string = (
-            urllib.parse.urlencode(multi_value_query_string_params, doseq=True).encode()
-            if multi_value_query_string_params
-            else b""
-        )
+
+        if is_http_api:
+            query_string = event.get('rawQueryString')
+        else:
+            multi_value_query_string_params = event["multiValueQueryStringParameters"]
+            query_string = (
+                    urllib.parse.urlencode(multi_value_query_string_params, doseq=True).encode()
+                    if multi_value_query_string_params
+                    else b""
+            )
+
+        event_path = event['requestContext']['http']['path'] if is_http_api else event["path"]
+        http_method = event['requestContext']['http']['method'] if is_http_api else event["httpMethod"]
+
         scope = {
-            "type": "http",
-            "http_version": "1.1",
-            "method": event["httpMethod"],
-            "headers": headers_key_value_pairs,
-            "path": self.strip_base_path(event["path"]),
-            "raw_path": None,
-            "root_path": "",
-            "scheme": headers.get("X-Forwarded-Proto", "https"),
-            "query_string": query_string,
-            "server": server,
-            "client": client,
-            "asgi": {"version": "3.0"},
-            "aws.event": event,
-            "aws.context": context,
+                "type":         "http",
+                "http_version": "1.1",
+                "method":       http_method,
+                "headers":      headers_key_value_pairs,
+                "path":         self.strip_base_path(event_path),
+                "raw_path":     None,
+                "root_path":    "",
+                "scheme":       headers.get("X-Forwarded-Proto", "https"),
+                "query_string": query_string,
+                "server":       server,
+                "client":       client,
+                "asgi":         {"version": "3.0"},
+                "aws.event":    event,
+                "aws.context":  context,
         }
 
         is_binary = event.get("isBase64Encoded", False)
-        body = event["body"] or b""
+        body = event.get("body") or b""
         if is_binary:
             body = base64.b64decode(body)
         elif not isinstance(body, bytes):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,62 @@ def mock_http_event(request):
 
 
 @pytest.fixture
+def mock_http_api_event(request):
+    method = request.param[0]
+    body = request.param[1]
+    multi_value_query_parameters = request.param[2]
+    query_string = request.param[3]
+    event = {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": "/my/path",
+        "rawQueryString": query_string,
+        "cookies": ["cookie1", "cookie2"],
+        "headers": {
+            "accept-encoding": "gzip,deflate",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https",
+            "host": "test.execute-api.us-west-2.amazonaws.com",
+        },
+        "queryStringParameters": {
+            k: v[0] for k, v in multi_value_query_parameters.items()
+        }
+        if multi_value_query_parameters
+        else None,
+        "requestContext": {
+            "accountId": "123456789012",
+            "apiId": "api-id",
+            "authorizer": {
+                "jwt": {
+                    "claims": {"claim1": "value1", "claim2": "value2"},
+                    "scopes": ["scope1", "scope2"],
+                }
+            },
+            "domainName": "id.execute-api.us-east-1.amazonaws.com",
+            "domainPrefix": "id",
+            "http": {
+                "method": method,
+                "path": "/my/path",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "192.168.100.1",
+                "userAgent": "agent",
+            },
+            "requestId": "id",
+            "routeKey": "$default",
+            "stage": "$default",
+            "time": "12/Mar/2020:19:03:58 +0000",
+            "timeEpoch": 1583348638390,
+        },
+        "body": body,
+        "pathParameters": {"parameter1": "value1"},
+        "isBase64Encoded": False,
+        "stageVariables": {"stageVariable1": "value1", "stageVariable2": "value2"},
+    }
+
+    return event
+
+
+@pytest.fixture
 def mock_ws_connect_event() -> dict:
     return {
         "headers": {

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -458,7 +458,7 @@ def test_http_api_gateway_base_path(mock_http_event) -> None:
         app, enable_lifespan=False, api_gateway_base_path=api_gateway_base_path
     )
     assert handler.strip_base_path(mock_http_event["path"]) == urllib.parse.unquote(
-        mock_http_event["path"][len(script_name) :]
+        mock_http_event["path"][len(script_name):]
     )
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -458,7 +458,7 @@ def test_http_api_gateway_base_path(mock_http_event) -> None:
         app, enable_lifespan=False, api_gateway_base_path=api_gateway_base_path
     )
     assert handler.strip_base_path(mock_http_event["path"]) == urllib.parse.unquote(
-        mock_http_event["path"][len(script_name):]
+        mock_http_event["path"][len(script_name) :]
     )
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -456,3 +456,107 @@ def test_http_api_gateway_base_path(mock_http_event) -> None:
     assert handler.strip_base_path(mock_http_event["path"]) == urllib.parse.unquote(
         mock_http_event["path"][len(script_name) :]
     )
+
+
+@pytest.mark.parametrize(
+    "mock_http_api_event",
+    [
+        (["GET", None, None, b""]),
+        (["GET", None, {"name": ["me"]}, b"name=me"]),
+        (["GET", None, {"name": ["me", "you"]}, b"name=me&name=you"]),
+        (
+            [
+                "GET",
+                None,
+                {"name": ["me", "you"], "pet": ["dog"]},
+                b"name=me&name=you&pet=dog",
+            ]
+        ),
+    ],
+    indirect=["mock_http_api_event"],
+)
+def test_http_request(mock_http_api_event) -> None:
+    async def app(scope, receive, send):
+        assert scope == {
+            "asgi": {"version": "3.0"},
+            "aws.context": {},
+            "aws.event": {
+                "version": "2.0",
+                "routeKey": "$default",
+                "rawPath": "/my/path",
+                "rawQueryString": mock_http_api_event["rawQueryString"],
+                "cookies": ["cookie1", "cookie2"],
+                "headers": {
+                    "accept-encoding": "gzip,deflate",
+                    "x-forwarded-port": "443",
+                    "x-forwarded-proto": "https",
+                    "host": "test.execute-api.us-west-2.amazonaws.com",
+                },
+                "queryStringParameters": mock_http_api_event["queryStringParameters"],
+                "requestContext": {
+                    "accountId": "123456789012",
+                    "apiId": "api-id",
+                    "authorizer": {
+                        "jwt": {
+                            "claims": {"claim1": "value1", "claim2": "value2"},
+                            "scopes": ["scope1", "scope2"],
+                        }
+                    },
+                    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+                    "domainPrefix": "id",
+                    "http": {
+                        "method": "GET",
+                        "path": "/my/path",
+                        "protocol": "HTTP/1.1",
+                        "sourceIp": "192.168.100.1",
+                        "userAgent": "agent",
+                    },
+                    "requestId": "id",
+                    "routeKey": "$default",
+                    "stage": "$default",
+                    "time": "12/Mar/2020:19:03:58 +0000",
+                    "timeEpoch": 1583348638390,
+                },
+                "body": None,
+                "pathParameters": {"parameter1": "value1"},
+                "isBase64Encoded": False,
+                "stageVariables": {
+                    "stageVariable1": "value1",
+                    "stageVariable2": "value2",
+                },
+            },
+            "client": ("192.168.100.1", 0),
+            "headers": [
+                [b"accept-encoding", b"gzip,deflate"],
+                [b"x-forwarded-port", b"443"],
+                [b"x-forwarded-proto", b"https"],
+                [b"host", b"test.execute-api.us-west-2.amazonaws.com"],
+            ],
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/my/path",
+            "query_string": mock_http_api_event["rawQueryString"],
+            "raw_path": None,
+            "root_path": "",
+            "scheme": "https",
+            "server": ("test.execute-api.us-west-2.amazonaws.com", 80),
+            "type": "http",
+        }
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain; charset=utf-8"]],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+    handler = Mangum(app, enable_lifespan=False)
+    response = handler(mock_http_api_event, {})
+    assert response == {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "headers": {"content-type": "text/plain; charset=utf-8"},
+        "body": "Hello, world!",
+    }


### PR DESCRIPTION
The proposed changes in this pull request brings initial support for the new HTTP API .
The _event_ dictionary passed to lambda from the new  [HTTP API](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) is different from the one expected from the traditional REST API therefore mangum fails in looking up some of the expected keys. 