### PR TITLE
Improve Dynamodb table name

### DIFF
--- a/mangum/backends/dynamodb.py
+++ b/mangum/backends/dynamodb.py
@@ -1,6 +1,6 @@
 import os
 
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import ParseResult, urlparse, parse_qs
 from dataclasses import dataclass
 
 import boto3
@@ -11,12 +11,19 @@ from mangum.backends.base import WebSocketBackend
 from mangum.exceptions import WebSocketError
 
 
+def get_table_name(parsed_dsn: ParseResult) -> str:
+    netloc = parsed_dsn.netloc
+    _, _, hostinfo = netloc.rpartition("@")
+    hostname, _, _ = hostinfo.partition(":")
+    return hostname
+
+
 @dataclass
 class DynamoDBBackend(WebSocketBackend):
     def __post_init__(self) -> None:
         parsed_dsn = urlparse(self.dsn)
         parsed_query = parse_qs(parsed_dsn.query)
-        table_name = parsed_dsn.hostname
+        table_name = get_table_name(parsed_dsn)
 
         region_name = (
             parsed_query["region"][0]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -43,14 +43,18 @@ def test_sqlite_3_backend(
     assert response == {"statusCode": 200}
 
 
+@pytest.mark.parametrize(
+    "table_name",
+    ["man", "mangum", "Mangum.Dev.001", "Mangum-Dev-001", "Mangum_Dev_002",],
+)
 @mock_dynamodb2
 def test_dynamodb_backend(
     mock_ws_connect_event,
     mock_ws_send_event,
     mock_ws_disconnect_event,
     mock_websocket_app,
+    table_name,
 ) -> None:
-    table_name = "mangum"
     region_name = "ap-southeast-1"
     dynamodb_resource = boto3.resource("dynamodb", region_name=region_name)
     dynamodb_resource.meta.client.create_table(


### PR DESCRIPTION
This PR improves Dynamodb table name for backend.

## Domain Name
I have copied code from python source code to create a function that gets table function.
https://github.com/python/cpython/blob/9d17cbf33df7cfb67ca0f37f6463ba5c18676641/Lib/urllib/parse.py#L198-L210

The function doesn't treat IPv6 style domain name.
I think don't need to care for Dynamodb.
https://github.com/python/cpython/blob/9d17cbf33df7cfb67ca0f37f6463ba5c18676641/Lib/urllib/parse.py#L156-L165
## Table Name Rule
I have added test cases following naming rule patterns.

*Table names and index names must be between 3 and 255 characters long, and can contain only the following characters:*
- `a-z`
- `A-Z`
- `0-9`
- `_` (underscore)
- `-` (dash)
- `.` (dot)

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html


## Related Issues
https://github.com/erm/mangum/issues/114