### PR TITLE
support WebSockets without body

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -253,7 +253,7 @@ class Mangum:
 
         elif event_type == "MESSAGE":
             websocket.fetch()
-            asgi_cycle = WebSocketCycle(event["body"], websocket=websocket)
+            asgi_cycle = WebSocketCycle(event.get("body", ""), websocket=websocket)
             response = asgi_cycle(self.app)
 
         elif event_type == "DISCONNECT":

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -70,3 +70,20 @@ def test_websocket_unexpected_message_error(
     handler = Mangum(app, dsn=dsn)
     response = handler(mock_ws_send_event, {})
     assert response == {"statusCode": 500}
+
+
+def test_websocket_without_body(
+    tmp_path, mock_ws_connect_event, mock_ws_send_event, mock_websocket_app
+) -> None:
+
+    dsn = f"sqlite://{tmp_path}/mangum.sqlite3"
+
+    handler = Mangum(mock_websocket_app, dsn=dsn)
+    response = handler(mock_ws_connect_event, {})
+    assert response == {"statusCode": 200}
+
+    with mock.patch("mangum.websocket.WebSocket.post_to_connection") as send:
+        send.return_value = None
+        del mock_ws_send_event["body"]
+        response = handler(mock_ws_send_event, {})
+        assert response == {"statusCode": 200}


### PR DESCRIPTION
This PR supports WebSockets without a body.

@erm 
I thought I should use `pytest.parametrize`  for this unittest.
But, I think It's too complex in the case.
Therefore, I deleted the `body` in an event dict.

## Related issues
#117